### PR TITLE
fix: Add React Native 0.72.x compatibility for codegen headers

### DIFF
--- a/cpp/NativeShikiEngineModule.h
+++ b/cpp/NativeShikiEngineModule.h
@@ -1,11 +1,15 @@
 #pragma once
 
-#if __has_include(<React-Codegen/NativeShikiEngineSpecJSI.h>)
+#if __has_include(<react/renderer/components/NativeShikiEngineSpec/NativeShikiEngineSpecJSI.h>)
+#include <react/renderer/components/NativeShikiEngineSpec/NativeShikiEngineSpecJSI.h>
+#elif __has_include(<React-Codegen/NativeShikiEngineSpecJSI.h>)
 #include <React-Codegen/NativeShikiEngineSpecJSI.h>
+#elif __has_include(<ReactCodegen/NativeShikiEngineSpecJSI.h>)
+#include <ReactCodegen/NativeShikiEngineSpecJSI.h>
 #elif __has_include(<NativeShikiEngineSpecJSI.h>)
 #include <NativeShikiEngineSpecJSI.h>
 #else
-#error "Could not find NativeShikiEngineSpecJSI.h"
+#error "Could not find NativeShikiEngineSpecJSI.h - ensure codegen has run and New Architecture is enabled"
 #endif
 
 #if __has_include("onig_regex.h")

--- a/react-native-shiki-engine.podspec
+++ b/react-native-shiki-engine.podspec
@@ -19,5 +19,11 @@ Pod::Spec.new do |s|
     "ios/**/*.{h,mm}",
   ]
 
+  if ENV['RCT_NEW_ARCH_ENABLED'] == '1'
+    s.pod_target_xcconfig = {
+      "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/Headers/Private/React-Codegen/react/renderer/components/NativeShikiEngineSpec\" \"$(PODS_ROOT)/Headers/Public/React-Codegen/react/renderer/components/NativeShikiEngineSpec\""
+    }
+  end
+
   install_modules_dependencies(s)
 end

--- a/src/NativeShikiEngine.ts
+++ b/src/NativeShikiEngine.ts
@@ -1,10 +1,9 @@
 import type { TurboModule } from 'react-native'
 import { TurboModuleRegistry } from 'react-native'
 
-interface Constants {}
-
 export interface Spec extends TurboModule {
-  readonly getConstants: () => Constants
+  // eslint-disable-next-line ts/no-empty-object-type
+  readonly getConstants: () => {}
   readonly createScanner: (patterns: readonly string[], maxCacheSize: number) => number
   readonly findNextMatchSync: (
     scannerId: number,


### PR DESCRIPTION
## Description
Fixes compatibility issues with React Native 0.72.x by adding support for the different codegen header paths and stricter type requirements used in that version.

## Problem
Users on React Native 0.72.7 were encountering build errors:
- `No template named 'NativeShikiEngineCxxSpec'`
- `Use of undeclared identifier 'CallInvoker'`
- `Could not find NativeShikiEngineSpecJSI.h`

This was caused by React Native's codegen structure changing between versions:
- **RN 0.72.x**: Uses `React-Codegen` (with hyphen) and generates headers in `react/renderer/components/[ModuleName]/`
- **RN 0.76+**: Uses `ReactCodegen` (no hyphen) and generates headers in `ReactCodegen/`

## Changes

### 1. Updated C++ Header Includes (`cpp/NativeShikiEngineModule.h`)
Added support for all React Native codegen header path variations:
- RN 0.72.x: `react/renderer/components/NativeShikiEngineSpec/NativeShikiEngineSpecJSI.h`
- RN 0.73-0.75: `React-Codegen/NativeShikiEngineSpecJSI.h`
- RN 0.76+: `ReactCodegen/NativeShikiEngineSpecJSI.h`

### 2. Updated Podspec (`react-native-shiki-engine.podspec`)
Added explicit header search paths for RN 0.72.x codegen output location when New Architecture is enabled.

### 3. Updated TypeScript Spec (`src/NativeShikiEngine.ts`)
Changed `getConstants()` return type from `Constants` interface to `{}` to satisfy RN 0.72.7's stricter codegen validation that requires explicit object literal types.

## Testing
- ✅ Verified compilation on React Native 0.72.7 (iOS)
- ✅ Module builds successfully without header errors
- ✅ Codegen generates files correctly
- ✅ Backward compatible with React Native 0.82.1

## Related Issues
Closes #167

## Breaking Changes
None - these changes are backward compatible with all supported React Native versions (0.71+).