### PR TITLE
build(react-native-shiki-engine): improve build compatibility

### DIFF
--- a/packages/react-native-shiki-engine/android/CMakeLists.txt
+++ b/packages/react-native-shiki-engine/android/CMakeLists.txt
@@ -41,10 +41,18 @@ target_compile_definitions(react-native-shiki-engine
 
 # Add codegen files
 set(CODEGEN_DIR "${CMAKE_CURRENT_SOURCE_DIR}/build/generated/source/codegen/jni")
-target_sources(react-native-shiki-engine PRIVATE
-    ${CODEGEN_DIR}/NativeShikiEngineSpec-generated.cpp
-    ${CODEGEN_DIR}/react/renderer/components/NativeShikiEngineSpec/NativeShikiEngineSpecJSI-generated.cpp
-)
+
+if(EXISTS "${CODEGEN_DIR}/NativeShikiEngineSpec-generated.cpp")
+    target_sources(react-native-shiki-engine PRIVATE
+        ${CODEGEN_DIR}/NativeShikiEngineSpec-generated.cpp
+    )
+endif()
+
+if(EXISTS "${CODEGEN_DIR}/react/renderer/components/NativeShikiEngineSpec/NativeShikiEngineSpecJSI-generated.cpp")
+    target_sources(react-native-shiki-engine PRIVATE
+        ${CODEGEN_DIR}/react/renderer/components/NativeShikiEngineSpec/NativeShikiEngineSpecJSI-generated.cpp
+    )
+endif()
 
 target_include_directories(react-native-shiki-engine PRIVATE
     ${CODEGEN_DIR}

--- a/packages/react-native-shiki-engine/android/build.gradle
+++ b/packages/react-native-shiki-engine/android/build.gradle
@@ -121,6 +121,14 @@ if (isNewArchitectureEnabled()) {
     codegenJavaPackageName = "com.shikiengine"
   }
 
+  // Disable buildCodegenCLI task for RN 0.72.7 compatibility
+  // RN 0.72.7 looks for a build.sh script that doesn't exist in the codegen package
+  tasks.configureEach { task ->
+    if (task.name == "buildCodegenCLI") {
+      task.enabled = false
+    }
+  }
+
   // Patch the auto-generated CMakeLists.txt to exclude Fabric component files
   tasks.configureEach { task ->
     if (task.name.contains("generateCodegenArtifactsFromSchema")) {

--- a/packages/react-native-shiki-engine/cpp/NativeShikiEngineModule.h
+++ b/packages/react-native-shiki-engine/cpp/NativeShikiEngineModule.h
@@ -1,5 +1,12 @@
 #pragma once
 
+#include <ReactCommon/CallInvoker.h>
+
+#include <jsi/jsi.h>
+
+#include <memory>
+#include <optional>
+
 #if __has_include(<react/renderer/components/NativeShikiEngineSpec/NativeShikiEngineSpecJSI.h>)
 #  include <react/renderer/components/NativeShikiEngineSpec/NativeShikiEngineSpecJSI.h>
 #elif __has_include(<React-Codegen/NativeShikiEngineSpecJSI.h>)

--- a/packages/react-native-shiki-engine/react-native-shiki-engine.podspec
+++ b/packages/react-native-shiki-engine/react-native-shiki-engine.podspec
@@ -21,7 +21,19 @@ Pod::Spec.new do |s|
 
   if ENV['RCT_NEW_ARCH_ENABLED'] == '1'
     s.pod_target_xcconfig = {
-      "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/Headers/Private/React-Codegen/react/renderer/components/NativeShikiEngineSpec\" \"$(PODS_ROOT)/Headers/Public/React-Codegen/react/renderer/components/NativeShikiEngineSpec\""
+      "HEADER_SEARCH_PATHS" => [
+        # RN 0.74+
+        "\"$(PODS_ROOT)/Headers/Private/ReactCodegen/react/renderer/components/NativeShikiEngineSpec\"",
+        "\"$(PODS_ROOT)/Headers/Public/ReactCodegen/react/renderer/components/NativeShikiEngineSpec\"",
+        # RN 0.71-0.73
+        "\"$(PODS_ROOT)/Headers/Private/React-Codegen/react/renderer/components/NativeShikiEngineSpec\"",
+        "\"$(PODS_ROOT)/Headers/Public/React-Codegen/react/renderer/components/NativeShikiEngineSpec\"",
+        # Fallback to root codegen headers
+        "\"$(PODS_ROOT)/Headers/Private/React-Codegen\"",
+        "\"$(PODS_ROOT)/Headers/Public/React-Codegen\"",
+        "\"$(PODS_ROOT)/Headers/Private/ReactCodegen\"",
+        "\"$(PODS_ROOT)/Headers/Public/ReactCodegen\""
+      ].join(" ")
     }
   end
 


### PR DESCRIPTION
- Add conditional checks for codegen-generated files in CMakeLists.txt to prevent build failures when files don't exist
- Split codegen source file additions into separate conditional blocks for better error handling
- Disable buildCodegenCLI task in build.gradle for React Native 0.72.7 compatibility
- Add missing C++ standard library includes (memory, optional) to NativeShikiEngineModule.h
- Update podspec HEADER_SEARCH_PATHS to support multiple React Native versions (0.71-0.74+)
- Add fallback header search paths for both React-Codegen and ReactCodegen package naming conventions