### PR TITLE
fix(ios): prevent duplicate header errors in Xcode build

### DIFF
--- a/packages/react-native-shiki-engine/react-native-shiki-engine.podspec
+++ b/packages/react-native-shiki-engine/react-native-shiki-engine.podspec
@@ -42,12 +42,12 @@ Pod::Spec.new do |s|
   if is_rn_73_or_higher
     s.source_files = [
       "cpp/**/*.{cpp,h}",
-      "apple/**/*.{h,mm}",
+      "apple/*.{h,mm}",
     ]
   else
     s.source_files = [
       "cpp/**/*.{cpp,h}",
-      "apple/**/*.{h,mm}",
+      "apple/*.{h,mm}",
     ]
     s.exclude_files = "apple/onLoad.mm"
   end


### PR DESCRIPTION
## Problem

When building an iOS project using `react-native-shiki-engine` with CocoaPods, Xcode fails with duplicate output file errors:

```
error: Multiple commands produce 'Headers/oniggnu.h'
error: Multiple commands produce 'Headers/oniguruma.h'
```

## Root Cause

The podspec's `source_files` pattern `apple/**/*.{h,mm}` was recursively matching headers inside the vendored `Oniguruma.xcframework`, causing CocoaPods to copy them twice:
1. As part of the vendored framework
2. As individual source files matching the glob pattern

## Solution

Changed `source_files` pattern from:
- `apple/**/*.{h,mm}` (recursive)

to:
- `apple/*.{h,mm}` (non-recursive)

This excludes the `apple/Oniguruma.xcframework/` directory while still including all necessary source files directly in the `apple/` directory.

## Testing

- ✅ Builds successfully on iOS simulator (x86_64, arm64)
- ✅ Builds successfully on iOS device (arm64)
- ✅ No duplicate header errors in Xcode
- ✅ All headers properly accessible to consuming projects

## Related

This is a build configuration issue specific to CocoaPods and doesn't affect functionality.