### PR TITLE
Fix out-of-bounds capture iteration in native scanner

### DIFF
--- a/packages/react-native-shiki-engine/cpp/onig_regex.cpp
+++ b/packages/react-native-shiki-engine/cpp/onig_regex.cpp
@@ -192,8 +192,9 @@ OnigResult* find_next_match(OnigContext* context, const char* text, int start_po
           result->match_end = context->region->end[0];
 
           delete[] result->capture_indices;
-          result->capture_count = context->region->num_regs * 2;
-          result->capture_indices = new int[result->capture_count];
+          // capture_count is the number of capture groups; indices store start/end pairs.
+          result->capture_count = context->region->num_regs;
+          result->capture_indices = new int[result->capture_count * 2];
 
           for (int j = 0; j < context->region->num_regs; j++) {
             result->capture_indices[j * 2] = context->region->beg[j];


### PR DESCRIPTION
## Summary

Fix a native capture-count contract mismatch in `packages/react-native-shiki-engine/cpp/onig_regex.cpp`.

`OnigResult.capture_count` should represent the number of capture groups, while `capture_indices` stores flattened `start/end` pairs.

## Root Cause

`find_next_match()` currently does this:

- `capture_count = context->region->num_regs * 2`
- `capture_indices = new int[capture_count]`

But `NativeShikiEngineModule::findNextMatchSync()` later treats `capture_count` as the number of capture objects and reads each object from `capture_indices[i * 2]` and `capture_indices[i * 2 + 1]`.

That means the `* 2` is applied twice:

- once when `capture_count` is written
- again when the result is marshaled back to JS

On matches with capture groups, this can read past the allocated buffer and crash in native code.

## Why I’m Sending This

I hit this in production while rendering syntax-highlighted markdown code blocks in a React Native app that uses this package.

Crash context:

- App version: `2.6.11 (1)`
- Device: `iPhone XS Max`
- OS: `iOS 16.0.2`
- Crashed thread: `com.facebook.react.runtime.JavaScript`
- Top native frame: `NativeShikiEngineModule::findNextMatchSync`

The relevant stack frames were:

```text
NativeShikiEngineModule::findNextMatchSync(...)
NativeShikiEngineCxxSpec::__findNextMatchSync(...)
hermes ...
```

And the out-of-bounds access lines up with the current marshaling loop in `NativeShikiEngineModule.cpp`, which expects `capture_count` to be the number of captures, not the number of ints in the flattened backing array.

## Fix

This PR makes the contract consistent by changing:

- `capture_count = context->region->num_regs`
- `capture_indices = new int[capture_count * 2]`

That preserves the existing JS/native marshaling logic and fixes the buffer sizing/count semantics at the source.

## Validation

- Confirmed the crash path against the symbolicated production stack trace
- Verified the current upstream source still has the mismatch
- Kept the patch minimal to the native result construction path

I did not run a full example app build in this repo before opening the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected regex capture group handling in the native engine to accurately interpret pattern matches and capture data, improving the reliability of pattern matching operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->