### PR TITLE
Retry iOS pod install after clean on CI

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -80,8 +80,20 @@ jobs:
             ${{ runner.os }}-pods-
 
       - name: Install Pods
-        run: bundle exec pod install
+        shell: bash
         working-directory: examples/react-native/ios
+        run: |
+          set -euo pipefail
+
+          install_pods() {
+            bundle exec pod install
+          }
+
+          if ! install_pods; then
+            echo "::warning::pod install failed; cleaning iOS artifacts and retrying once"
+            rm -rf Pods build
+            install_pods
+          fi
 
       - name: Build App
         run: |


### PR DESCRIPTION
## Summary

Retry `bundle exec pod install` once in the iOS workflow after cleaning generated iOS artifacts.

## Why

The current iOS check is intermittently failing during `pod install` on GitHub Actions with:

```text
ArgumentError - pathname contains null byte
```

This happens before any package compile step, so it is not caused by the Shiki native C++ change itself.

In the failing run for PR #221:

- the failure happened in the `Install Pods` step
- the Pods cache was **not** restored
- the same workflow/environment has also succeeded recently on other PRs

That points to an intermittent CocoaPods/workflow issue rather than a deterministic package bug.

## Rationale for this fix

The failure mode matches the known intermittent CocoaPods null-byte issue reported for React Native + pnpm setups on GitHub Actions:

- CocoaPods/CocoaPods#12798
- CocoaPods/CocoaPods#12866

Since the failure is flaky and happens during `pod install`, the narrowest CI mitigation is to retry once after removing generated iOS artifacts:

- `Pods`
- `build`

This keeps the fix scoped to CI and avoids changing the package or example app configuration.

## Validation

- Inspected the failing workflow log for PR #221
- Confirmed the failure occurs in `Install Pods`, before compilation
- Confirmed the run had a Pods cache miss, so the retry is not masking a stale cache hit
- Kept the change isolated to `.github/workflows/build-ios.yml`

I did not run the full iOS workflow locally before opening this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * iOS build process enhancements include stricter error handling and an automatic retry mechanism for pod dependency installation. When installation fails initially, the system emits a warning, cleans up cached artifacts and build outputs, and automatically retries the installation once. These improvements increase overall build reliability and help minimize intermittent build failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->