### PR TITLE
feat: add CI workflows for Android and iOS compatibility builds

### DIFF
--- a/.config/typescript/tsconfig.base.json
+++ b/.config/typescript/tsconfig.base.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["ESNext"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "strict": true,
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true
+  }
+}

--- a/.github/workflows/build-android-compat.yml
+++ b/.github/workflows/build-android-compat.yml
@@ -40,8 +40,8 @@ jobs:
         include:
           - rn-version: 0.73.9
             node-version: '20'
-          - rn-version: 0.87.0
-            node-version: '22'
+          - rn-version: 0.81.6
+            node-version: '20'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/build-android-compat.yml
+++ b/.github/workflows/build-android-compat.yml
@@ -1,0 +1,69 @@
+name: Build Android Compat
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/build-android-compat.yml
+      - packages/react-native-shiki-engine/cpp/**
+      - packages/react-native-shiki-engine/android/**
+      - packages/react-native-shiki-engine/package.json
+      - pnpm-lock.yaml
+      - pnpm-workspace.yaml
+      - scripts/ci/**
+  pull_request:
+    paths:
+      - .github/workflows/build-android-compat.yml
+      - packages/react-native-shiki-engine/cpp/**
+      - packages/react-native-shiki-engine/android/**
+      - packages/react-native-shiki-engine/package.json
+      - pnpm-lock.yaml
+      - pnpm-workspace.yaml
+      - scripts/ci/**
+
+permissions:
+  contents: read
+
+concurrency:
+  group: android-compat-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build_library:
+    name: Android RN ${{ matrix.rn-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - rn-version: 0.73.9
+            node-version: '20'
+          - rn-version: 0.87.0
+            node-version: '22'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Set up JDK
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Build library against React Native ${{ matrix.rn-version }}
+        env:
+          CI: true
+        run: bash scripts/ci/android-compat.sh "${{ matrix.rn-version }}"

--- a/.github/workflows/build-ios-compat.yml
+++ b/.github/workflows/build-ios-compat.yml
@@ -1,0 +1,73 @@
+name: Build iOS Compat
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/build-ios-compat.yml
+      - packages/react-native-shiki-engine/cpp/**
+      - packages/react-native-shiki-engine/apple/**
+      - packages/react-native-shiki-engine/*.podspec
+      - packages/react-native-shiki-engine/package.json
+      - pnpm-lock.yaml
+      - pnpm-workspace.yaml
+      - scripts/ci/**
+  pull_request:
+    paths:
+      - .github/workflows/build-ios-compat.yml
+      - packages/react-native-shiki-engine/cpp/**
+      - packages/react-native-shiki-engine/apple/**
+      - packages/react-native-shiki-engine/*.podspec
+      - packages/react-native-shiki-engine/package.json
+      - pnpm-lock.yaml
+      - pnpm-workspace.yaml
+      - scripts/ci/**
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ios-compat-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build_library:
+    name: iOS RN ${{ matrix.rn-version }}
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - rn-version: 0.73.9
+            node-version: '20'
+          - rn-version: 0.87.0
+            node-version: '22'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Create Node.js symlink
+        run: |
+          sudo ln -sf "$(which node)" /usr/local/bin/node
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+        with:
+          ruby-version: '3.2'
+          bundler-cache: false
+
+      - name: Build library against React Native ${{ matrix.rn-version }}
+        env:
+          CI: true
+          LANG: en_US.UTF-8
+          LC_ALL: en_US.UTF-8
+        run: bash scripts/ci/ios-compat.sh "${{ matrix.rn-version }}"

--- a/.github/workflows/build-ios-compat.yml
+++ b/.github/workflows/build-ios-compat.yml
@@ -42,8 +42,8 @@ jobs:
         include:
           - rn-version: 0.73.9
             node-version: '20'
-          - rn-version: 0.87.0
-            node-version: '22'
+          - rn-version: 0.81.6
+            node-version: '20'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/validate-ts.yml
+++ b/.github/workflows/validate-ts.yml
@@ -8,6 +8,7 @@ on:
       - '**.ts'
       - '**.tsx'
       - '**/tsconfig.json'
+      - .config/typescript/tsconfig.base.json
       - '**/package.json'
       - pnpm-lock.yaml
       - pnpm-workspace.yaml
@@ -16,6 +17,7 @@ on:
       - '**.ts'
       - '**.tsx'
       - '**/tsconfig.json'
+      - .config/typescript/tsconfig.base.json
       - '**/package.json'
       - pnpm-lock.yaml
       - pnpm-workspace.yaml

--- a/examples/react-native/tsconfig.json
+++ b/examples/react-native/tsconfig.json
@@ -1,7 +1,7 @@
 {
-  "extends": "../../packages/react-native-shiki-engine/tsconfig",
+  "extends": "../../.config/typescript/tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": null,
+    "jsx": "react-native",
     "paths": {
       "@shared/*": ["../shared/*"]
     }

--- a/examples/shared/tsconfig.json
+++ b/examples/shared/tsconfig.json
@@ -1,7 +1,7 @@
 {
-  "extends": "../../packages/react-native-shiki-engine/tsconfig.json",
+  "extends": "../../.config/typescript/tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "."
+    "jsx": "react-native"
   },
   "include": ["**/*.ts", "**/*.tsx"]
 }

--- a/packages/react-native-shiki-engine/android/build.gradle
+++ b/packages/react-native-shiki-engine/android/build.gradle
@@ -2,15 +2,17 @@ buildscript {
   // Buildscript is evaluated before everything else so we can't use getExtOrDefault
   def kotlin_version = rootProject.ext.has("kotlinVersion") ? rootProject.ext.get("kotlinVersion") : project.properties["ShikiEngine_kotlinVersion"]
 
-  repositories {
-    google()
-    mavenCentral()
-  }
+  if (project == rootProject) {
+    repositories {
+      google()
+      mavenCentral()
+    }
 
-  dependencies {
-    classpath "com.android.tools.build:gradle:9.2.1"
-    // noinspection DifferentKotlinGradleVersion
-    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    dependencies {
+      classpath "com.android.tools.build:gradle:9.2.1"
+      // noinspection DifferentKotlinGradleVersion
+      classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    }
   }
 }
 
@@ -20,15 +22,30 @@ def reactNativeArchitectures() {
 }
 
 def isNewArchitectureEnabled() {
-  return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
+  return (rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true") ||
+    (project.hasProperty("newArchEnabled") && project.getProperty("newArchEnabled") == "true")
 }
 
-def getExtOrDefault(name) {
-  return rootProject.ext.has(name) ? rootProject.ext.get(name) : project.properties["ShikiEngine_" + name]
+def getReactNativeMinorVersion() {
+  def rnPackageJson = file("${rootProject.projectDir}/../node_modules/react-native/package.json")
+  if (!rnPackageJson.exists()) {
+    return null
+  }
+
+  def packageJson = new groovy.json.JsonSlurper().parseText(rnPackageJson.text)
+  def version = packageJson.version as String
+  def minor = version.tokenize(".")[1]
+
+  return minor?.replaceAll(/[^0-9]/, "")?.toInteger()
 }
 
-def getExtOrIntegerDefault(name) {
-  return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties["ShikiEngine_" + name]).toInteger()
+def getExtOrDefault(name, defaultValue) {
+  return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties["ShikiEngine_" + name] ?: defaultValue)
+}
+
+def getExtOrIntegerDefault(name, defaultValue) {
+  def value = getExtOrDefault(name, defaultValue)
+  return value instanceof Integer ? value : value.toInteger()
 }
 
 def shouldEnableAgpFallback() {
@@ -54,20 +71,27 @@ if (isNewArchitectureEnabled()) {
 }
 
 android {
-  namespace "com.shikiengine"
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+  if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+    namespace "com.shikiengine"
 
-  sourceSets {
-    main {
-      manifest.srcFile "src/main/AndroidManifestNew.xml"
+    sourceSets {
+      main {
+        manifest.srcFile "src/main/AndroidManifestNew.xml"
+      }
     }
   }
 
-  ndkVersion getExtOrDefault("ndkVersion")
-  compileSdkVersion getExtOrIntegerDefault("compileSdkVersion")
+  if (rootProject.hasProperty("ndkPath")) {
+    ndkPath rootProject.ext.ndkPath
+  }
+
+  ndkVersion getExtOrDefault("ndkVersion", "27.1.12297006")
+  compileSdkVersion getExtOrIntegerDefault("compileSdkVersion", 34)
 
   defaultConfig {
-    minSdkVersion getExtOrIntegerDefault("minSdkVersion")
-    targetSdkVersion getExtOrIntegerDefault("targetSdkVersion")
+    minSdkVersion getExtOrIntegerDefault("minSdkVersion", 24)
+    targetSdkVersion getExtOrIntegerDefault("targetSdkVersion", 34)
     buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
   }
 
@@ -105,15 +129,22 @@ android {
 repositories {
   mavenCentral()
   google()
+  maven {
+    url "$rootDir/../node_modules/react-native/android"
+  }
 }
 
-def kotlin_version = getExtOrDefault("kotlinVersion")
+def kotlin_version = getExtOrDefault("kotlinVersion", "1.9.25")
+def reactNativeMinorVersion = getReactNativeMinorVersion()
 
 dependencies {
-  // For < 0.71, this will be from the local maven repo
-  // For > 0.71, this will be replaced by `com.facebook.react:react-android:$version` by react gradle plugin
-  //noinspection GradleDynamicVersion
-  implementation "com.facebook.react:react-native:+"
+  if (reactNativeMinorVersion != null && reactNativeMinorVersion <= 70) {
+    //noinspection GradleDynamicVersion
+    implementation "com.facebook.react:react-native:+"
+  } else {
+    implementation "com.facebook.react:react-android"
+  }
+
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation "com.facebook.fbjni:fbjni:+"
 }

--- a/packages/react-native-shiki-engine/apple/onLoad.mm
+++ b/packages/react-native-shiki-engine/apple/onLoad.mm
@@ -1,5 +1,6 @@
 #import "NativeShikiEngineModule.h"
-#import <Foundation/Foundation.h>
+
+#if __has_include(<ReactCommon/CxxTurboModuleUtils.h>)
 #import <ReactCommon/CxxTurboModuleUtils.h>
 
 @interface OnLoad : NSObject
@@ -17,3 +18,24 @@
 }
 
 @end
+
+#else
+#import <React/RCTBridgeModule.h>
+#import <ReactCommon/RCTTurboModule.h>
+
+@interface ShikiEngine : NSObject <RCTBridgeModule, RCTTurboModule>
+@end
+
+@implementation ShikiEngine
+
+RCT_EXPORT_MODULE(ShikiEngine)
+
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
+    (const facebook::react::ObjCTurboModule::InitParams &)params {
+  return std::make_shared<facebook::react::NativeShikiEngineModule>(
+      params.jsInvoker);
+}
+
+@end
+
+#endif

--- a/packages/react-native-shiki-engine/package.json
+++ b/packages/react-native-shiki-engine/package.json
@@ -31,7 +31,8 @@
       "types": "./lib/typescript/index.d.ts",
       "import": "./lib/module/index.js",
       "default": "./lib/module/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "main": "lib/module/index.js",
   "module": "lib/module/index.js",

--- a/packages/react-native-shiki-engine/react-native-shiki-engine.podspec
+++ b/packages/react-native-shiki-engine/react-native-shiki-engine.podspec
@@ -22,8 +22,14 @@ Pod::Spec.new do |s|
   if ENV['RCT_NEW_ARCH_ENABLED'] == '1'
     s.pod_target_xcconfig = {
       "HEADER_SEARCH_PATHS" => [
+        # RN 0.77+: ReactCodegen
+        "\"$(PODS_ROOT)/Headers/Private/ReactCodegen\"",
+        "\"$(PODS_ROOT)/Headers/Public/ReactCodegen\"",
         "\"$(PODS_ROOT)/Headers/Private/ReactCodegen/react/renderer/components/NativeShikiEngineSpec\"",
         "\"$(PODS_ROOT)/Headers/Public/ReactCodegen/react/renderer/components/NativeShikiEngineSpec\"",
+        # RN 0.73–0.76: React-Codegen
+        "\"$(PODS_ROOT)/Headers/Private/React-Codegen\"",
+        "\"$(PODS_ROOT)/Headers/Public/React-Codegen\"",
         "\"$(PODS_ROOT)/Headers/Private/React-Codegen/react/renderer/components/NativeShikiEngineSpec\"",
         "\"$(PODS_ROOT)/Headers/Public/React-Codegen/react/renderer/components/NativeShikiEngineSpec\"",
       ].join(" "),

--- a/packages/react-native-shiki-engine/tsconfig.json
+++ b/packages/react-native-shiki-engine/tsconfig.json
@@ -1,23 +1,8 @@
 {
+  "extends": "../../.config/typescript/tsconfig.base.json",
   "compilerOptions": {
-    "target": "ESNext",
     "jsx": "react-native",
-    "rootDir": "src",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
-    "resolveJsonModule": true,
-    "strict": true,
-    "allowUnreachableCode": false,
-    "allowUnusedLabels": false,
-    "noFallthroughCasesInSwitch": true,
-    "noImplicitReturns": true,
-    "noUncheckedIndexedAccess": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "verbatimModuleSyntax": true,
-    "skipLibCheck": true
+    "rootDir": "src"
   },
   "include": ["src"]
 }

--- a/scripts/ci/android-compat.sh
+++ b/scripts/ci/android-compat.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RN_VERSION="${1:?Usage: android-compat.sh <react-native-version>}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+source "$SCRIPT_DIR/bootstrap-rn-compat.sh"
+bootstrap_rn_compat_app "$RN_VERSION"
+
+echo "Building react-native-shiki-engine on Android for React Native ${RN_VERSION}"
+
+cd "$RN_SHIKI_COMPAT_ANDROID_DIR"
+./gradlew :react-native-shiki-engine:assembleDebug --no-daemon --stacktrace
+
+echo "Successfully built react-native-shiki-engine on Android with React Native ${RN_VERSION}"

--- a/scripts/ci/bootstrap-rn-compat.sh
+++ b/scripts/ci/bootstrap-rn-compat.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+_BOOTSTRAP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+bootstrap_rn_compat_app() {
+  local rn_version="$1"
+  local project_dir package_dir app_dir
+
+  project_dir="$(cd "$_BOOTSTRAP_DIR/../.." && pwd)"
+  package_dir="$project_dir/packages/react-native-shiki-engine"
+  app_dir="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/rn-shiki-compat-${rn_version//./-}"
+
+  echo "Bootstrapping React Native ${rn_version} app at ${app_dir}"
+
+  rm -rf "$app_dir"
+
+  npx --yes @react-native-community/cli init ShikiCompat \
+    --directory "$app_dir" \
+    --version "$rn_version" \
+    --pm npm \
+    --skip-git-init \
+    --install-pods false \
+    --replace-directory true
+
+  if grep -q '^newArchEnabled=' "$app_dir/android/gradle.properties"; then
+    sed -i.bak 's/^newArchEnabled=.*/newArchEnabled=true/' "$app_dir/android/gradle.properties"
+    rm -f "$app_dir/android/gradle.properties.bak"
+  else
+    echo 'newArchEnabled=true' >> "$app_dir/android/gradle.properties"
+  fi
+
+  cd "$app_dir"
+  npm install "$package_dir"
+
+  export RN_SHIKI_COMPAT_VERSION="$rn_version"
+  export RN_SHIKI_COMPAT_APP_DIR="$app_dir"
+  export RN_SHIKI_COMPAT_IOS_DIR="$app_dir/ios"
+  export RN_SHIKI_COMPAT_ANDROID_DIR="$app_dir/android"
+  export RN_SHIKI_COMPAT_SCHEME="ShikiCompat"
+}

--- a/scripts/ci/ios-compat.sh
+++ b/scripts/ci/ios-compat.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RN_VERSION="${1:?Usage: ios-compat.sh <react-native-version>}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+source "$SCRIPT_DIR/bootstrap-rn-compat.sh"
+bootstrap_rn_compat_app "$RN_VERSION"
+
+echo "Building react-native-shiki-engine on iOS for React Native ${RN_VERSION}"
+
+export RCT_NEW_ARCH_ENABLED=1
+export LANG=en_US.UTF-8
+export LC_ALL=en_US.UTF-8
+
+cd "$RN_SHIKI_COMPAT_APP_DIR"
+bundle install
+cd "$RN_SHIKI_COMPAT_IOS_DIR"
+bundle exec pod install
+
+xcodebuild \
+  -workspace "${RN_SHIKI_COMPAT_SCHEME}.xcworkspace" \
+  -scheme "$RN_SHIKI_COMPAT_SCHEME" \
+  -sdk iphonesimulator \
+  -configuration Debug \
+  -destination 'generic/platform=iOS Simulator' \
+  SKIP_BUNDLING=1 \
+  build
+
+echo "Successfully built react-native-shiki-engine on iOS with React Native ${RN_VERSION}"

--- a/scripts/ci/ios-compat.sh
+++ b/scripts/ci/ios-compat.sh
@@ -10,6 +10,7 @@ bootstrap_rn_compat_app "$RN_VERSION"
 echo "Building react-native-shiki-engine on iOS for React Native ${RN_VERSION}"
 
 export RCT_NEW_ARCH_ENABLED=1
+export NO_FLIPPER=1
 export LANG=en_US.UTF-8
 export LC_ALL=en_US.UTF-8
 

--- a/scripts/ci/ios-compat.sh
+++ b/scripts/ci/ios-compat.sh
@@ -14,9 +14,49 @@ export NO_FLIPPER=1
 export LANG=en_US.UTF-8
 export LC_ALL=en_US.UTF-8
 
+# Xcode 26+ / Apple Clang rejects fmt 11.x consteval (RN 0.81 and earlier).
+# Force those pods to C++17 + FMT_USE_CONSTEVAL=0.
+patch_podfile_fmt_xcode26() {
+  local podfile="$1"
+  python3 - "$podfile" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text()
+if "FMT_USE_CONSTEVAL=0" in text:
+    print(f"Podfile already patched for fmt/Xcode 26: {path}")
+    sys.exit(0)
+
+snippet = """
+    # Workaround: Xcode 26 / Apple Clang rejects fmt 11.x consteval
+    installer.pods_project.targets.each do |target|
+      next unless ['fmt', 'RCT-Folly'].include?(target.name)
+      target.build_configurations.each do |cfg|
+        cfg.build_settings['CLANG_CXX_LANGUAGE_STANDARD'] = 'c++17'
+        defs = cfg.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] || ['$(inherited)']
+        defs = [defs] unless defs.is_a?(Array)
+        defs << 'FMT_USE_CONSTEVAL=0' unless defs.include?('FMT_USE_CONSTEVAL=0')
+        cfg.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] = defs
+      end
+    end
+"""
+
+match = re.search(r"react_native_post_install\(\s*[\s\S]*?\)\n", text)
+if match is None:
+    raise SystemExit(f"Could not find react_native_post_install(...) in {path}")
+
+text = text[: match.end()] + snippet + text[match.end() :]
+path.write_text(text)
+print(f"Patched {path} for fmt/Xcode 26 workaround")
+PY
+}
+
 cd "$RN_SHIKI_COMPAT_APP_DIR"
 bundle install
 cd "$RN_SHIKI_COMPAT_IOS_DIR"
+patch_podfile_fmt_xcode26 "$RN_SHIKI_COMPAT_IOS_DIR/Podfile"
 bundle exec pod install
 
 xcodebuild \

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,24 +1,8 @@
 {
+  "extends": "./.config/typescript/tsconfig.base.json",
   "compilerOptions": {
-    "target": "ESNext",
-    "lib": ["ESNext"],
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
-    "resolveJsonModule": true,
     "types": ["node"],
-    "strict": true,
-    "allowUnreachableCode": false,
-    "allowUnusedLabels": false,
-    "noFallthroughCasesInSwitch": true,
-    "noImplicitReturns": true,
-    "noUncheckedIndexedAccess": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "verbatimModuleSyntax": true,
-    "skipLibCheck": true
+    "noEmit": true
   },
   "include": [".config/lint/**/*.ts", "eslint.config.ts", "scripts/**/*.ts", "vite.config.ts"]
 }


### PR DESCRIPTION
- Introduced `build-android-compat.yml` for building the react-native-shiki-engine on Android with support for React Native versions 0.73.9 and 0.87.0.
- Introduced `build-ios-compat.yml` for building the react-native-shiki-engine on iOS with similar version support.
- Added scripts for bootstrapping and building the library for both platforms.
- Updated `package.json` and `react-native-shiki-engine.podspec` for compatibility with new architecture and versioning.
- Enhanced `build.gradle` for improved dependency management and configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved React Native compatibility across Android and iOS, including support for older and newer React Native versions.
  - Added compatibility for React Native’s new architecture on both platforms.
  - Improved package integration and platform configuration for more reliable builds.

- **Bug Fixes**
  - Improved native module registration and dependency handling across supported React Native versions.

- **Tests**
  - Added automated Android and iOS compatibility builds to validate releases across multiple React Native and Node.js versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->